### PR TITLE
fix: Correct detection box rendering with letterboxed/pillarboxed video

### DIFF
--- a/CoreMLPlayer/Views/SubViews/DetectionView.swift
+++ b/CoreMLPlayer/Views/SubViews/DetectionView.swift
@@ -32,7 +32,7 @@ struct DetectionView: View {
                         .offset(x: videoRect.origin.x, y: videoRect.origin.y)
                         .overlay {
                             GeometryReader { videoGeometry in
-                                forEachBB(detectedObjects: detectedObjects, geometry: videoGeometry)
+                                forEachBB(detectedObjects: detectedObjects, geometry: videoGeometry, videoSize: videoSize)
                             }
                         }
                 }
@@ -62,10 +62,10 @@ struct DetectionView: View {
         return CGRect(x: offsetX, y: offsetY, width: width, height: height)
     }
     
-    func forEachBB(detectedObjects: [DetectedObject], geometry: GeometryProxy) -> some View {
+    func forEachBB(detectedObjects: [DetectedObject], geometry: GeometryProxy, videoSize: CGSize? = nil) -> some View {
         ForEach(detectedObjects) { obj in
             let confidence = Double(obj.confidence) ?? 0
-            let drawingRect = base.prepareObjectForSwiftUI(object: obj, geometry: geometry)
+            let drawingRect = base.prepareObjectForSwiftUI(object: obj, geometry: geometry, videoSize: videoSize)
             if drawSettings.confidenceFiltered && confidence < drawSettings.confidenceLimit {
                 EmptyView()
             } else {

--- a/CoreMLPlayer/Views/SubViews/DetectionView.swift
+++ b/CoreMLPlayer/Views/SubViews/DetectionView.swift
@@ -24,7 +24,8 @@ struct DetectionView: View {
     
     var body: some View {
         GeometryReader { geometry in
-            if let videoSize, let videoRect = getVideoRect(geometrySize: geometry.size, videoSize: videoSize) {
+            if let videoSize {
+                let videoRect = getVideoRect(geometrySize: geometry.size, videoSize: videoSize)
                 ZStack {
                     VStack { EmptyView() }
                         .frame(width: videoRect.width, height: videoRect.height)


### PR DESCRIPTION
## Summary
Fixes detection boxes appearing as vertical lines when video is letterboxed or pillarboxed.

## Problem
Detection coordinates are normalized to original video dimensions, but were being transformed using the container geometry size. This caused incorrect rendering when the video aspect ratio differed from the container.

## Solution
Modified `prepareObjectForSwiftUI` to accept an optional `videoSize` parameter:
- Uses actual video dimensions for coordinate transformation  
- Scales transformed coordinates to fit the container geometry
- Maintains backward compatibility

## Changes
- `Base.swift`: Updated `prepareObjectForSwiftUI` with videoSize parameter
- `DetectionView.swift`: Pass videoSize through to coordinate transformation
- Added documentation explaining the bug

## Test Plan
- ✅ Build succeeds
- ✅ App launches correctly  
- ✅ Detection boxes now render with proper aspect ratios

## Related
Fixes: https://github.com/andrewginns/CoreMLPlayer/issues/3
Documentation: https://github.com/ebowwa/CoreMLPlayer/blob/fix/detection-box-rendering/docs/bug-detection-box-rendering.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)